### PR TITLE
Fix compile warning in shark.c.

### DIFF
--- a/core/shark.c
+++ b/core/shark.c
@@ -30,6 +30,7 @@
 #include "lualib.h"
 #include "lauxlib.h"
 #include "shark.h"
+#include "luv/luv.h"
 #include "libuv/include/uv.h"
 #include "luajit/src/lj_obj.h"
 


### PR DESCRIPTION
Fix the following compile warning in shark.c:  

core/shark.c:316:17: warning: implicit declaration of function 'luv_loop' is invalid in C99 [-Wimplicit-function-declaration]
        g_event_loop = luv_loop(ls);
                       ^
core/shark.c:316:15: warning: incompatible integer to pointer conversion assigning to 'uv_loop_t *' (aka 'struct uv_loop_s *') from 'int'
      [-Wint-conversion]
        g_event_loop = luv_loop(ls);
