### PR TITLE
Fix compile warning in core/shark.c.

### DIFF
--- a/core/shark.c
+++ b/core/shark.c
@@ -316,7 +316,7 @@ int main(int argc, char **argv)
 
 	g_event_loop = luv_loop(ls);
 
-	if(ret = luaL_loadfile(ls, argv[script])) {
+	if((ret = luaL_loadfile(ls, argv[script]))) {
 		ret = lua_report(ls, ret);
 		goto out;
 	}


### PR DESCRIPTION
Fix `clang` compile warning in core/shark.c:  

```
core/shark.c:319:9: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
        if(ret = luaL_loadfile(ls, argv[script])) {
           ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
core/shark.c:319:9: note: place parentheses around the assignment to silence this warning
        if(ret = luaL_loadfile(ls, argv[script])) {
               ^
           (                                    )
core/shark.c:319:9: note: use '==' to turn this assignment into an equality comparison
        if(ret = luaL_loadfile(ls, argv[script])) {
               ^
               ==
1 warning generated.
```
