### PR TITLE
Fix compile warnings in bpf/bpf.c.

### DIFF
--- a/bpf/bpf.c
+++ b/bpf/bpf.c
@@ -23,8 +23,10 @@
 #include <limits.h>
 #include <unistd.h>
 #include <errno.h>
+#include <linux/bpf.h>
 #include <poll.h>
 
+#include "libbpf.h"
 #include "bpf_load.h"
 #include "bpf_map_def.h"
 


### PR DESCRIPTION
Fix following compile warnings:

```
In file included from bpf/bpf.c:44:0:
bpf/bpf_map_index_func.h: In function ‘map_index_u8_u8_func’:
bpf/bpf_map_index_func.h:18:2: warning: implicit declaration of function ‘bpf_lookup_elem’ [-Wimplicit-function-declaration]
  bpf_lookup_elem(fd, &key, &val);
  ^
In file included from bpf/bpf.c:45:0:
bpf/bpf_map_newindex_func.h: In function ‘map_newindex_u8_u8_func’:
bpf/bpf_map_newindex_func.h:11:2: warning: implicit declaration of function ‘bpf_update_elem’ [-Wimplicit-function-declaration]
  bpf_update_elem(fd, &key, &val, BPF_ANY);
  ^
In file included from bpf/bpf.c:46:0:
bpf/bpf_map_next_func.h: In function ‘map_next_u8_func’:
bpf/bpf_map_next_func.h:12:6: warning: implicit declaration of function ‘bpf_get_next_key’ [-Wimplicit-function-declaration]
  if (bpf_get_next_key(fd, &key, &nextkey) == 0) {
      ^
bpf/bpf.c: In function ‘shark_create_bpf_map’:
bpf/bpf.c:170:15: warning: implicit declaration of function ‘bpf_create_map’ [-Wimplicit-function-declaration]
   map_fd[i] = bpf_create_map(maps[i].type,
               ^
```
