### PR TITLE
Check return value of lua_pcall in core/shark.c.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ shark project expect to delieve a unified event API, user can programming the
 API, we believe that a well designed system tracing and monitoring API is the
 fundamental base for Consistent commandline tools and Cloud monitoring.
 
-We already developed lua perf event API, more API will be support soon.
+We already developed lua perf event API, more API will be supportted soon.
 
 *Consistent commandline tools*
 

--- a/core/shark.c
+++ b/core/shark.c
@@ -310,7 +310,10 @@ int main(int argc, char **argv)
 #include "shark_init.h"
 	luaL_loadbuffer(ls, luaJIT_BC_shark_init, luaJIT_BC_shark_init_SIZE,
 			NULL);
-	lua_pcall(ls, 0, 0, 0);
+	if((ret = lua_pcall(ls, 0, 0, 0))) {
+		ret = lua_report(ls, ret);
+		goto out;
+	}
 
 	g_event_loop = luv_loop(ls);
 


### PR DESCRIPTION
Hi Shark,

I think it is need to check the return value of lua_pcall. BTW, in the following code:  

```
if (lua_pcall(ls, 0, 0, base)) {
    fprintf(stderr, "%s\n", lua_tostring(ls, -1));
    exit(EXIT_FAILURE);
}
```

I think it is also possible to use `lua_report` instead of `fprintf`. Could you give comments? Thanks in advance!

Best Regards
Nan Xiao 
